### PR TITLE
Fix | Update Secure Flag on Cookies

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -62,7 +62,7 @@ export default class AuthController {
       res.cookie('auth', user.token ?? '', {
         httpOnly: true,
         sameSite: true,
-        secure: false,
+        secure: true,
         expires: user.tokenExpiration ?? new Date()
       });
 


### PR DESCRIPTION
# Description

I identified that we were not setting the `secure` flag on our access token cookies.  We want to do that so that cookies are only sent over HTTPS and all traffic for the site should use HTTPS

## Proposed Changes

- Update the auth controller to set `secure: true` when creating the cookie